### PR TITLE
BlockDataの文字列表現を改善

### DIFF
--- a/kkloader/KoikatuCharaData.py
+++ b/kkloader/KoikatuCharaData.py
@@ -211,11 +211,14 @@ class BlockData:
     def __delitem__(self, key):
         del self.data[key]
 
+    def __repr__(self):
+        return self.__str__()
+
     def prettify(self):
         print(self.__str__())
 
     def __str__(self):
-        return json.dumps(self.jsonalizable(), indent=2, default=bin_to_str)
+        return json.dumps(self.jsonalizable(), indent=2, ensure_ascii=False, default=bin_to_str)
 
 
 class Custom(BlockData):


### PR DESCRIPTION
## 変更内容
- `BlockData` クラスに `__repr__` メソッドを追加
- `__str__` メソッドで `ensure_ascii=False` を指定

## 変更理由
- `__repr__` を実装することで、REPL やデバッグ時の表示が改善されます
- `ensure_ascii=False` により、日本語などの非ASCII文字が正しく表示されるようになります（`\u3042` のようなエスケープシーケンスではなく、`あ` のように表示）

## 例

以下のコマンドを実行した際に、
```python
from kkloader import AicomiCharaData

chara = AicomiCharaData.load('./data/ac_chara.png')
chara.Parameter.prettify()
```

今まででは以下のようになっていたが、
```json
{
  "version": "0.0.0",
  "sex": 1,
  "lastname": "\u77f3\u5ddd",
  "firstname": "\u4f73\u7a42",
  "nickname": "\u304b\u307b",
  "personality": 3,
  "bloodType": 2,
  "birthMonth": 7,
  "birthDay": 10,
  "voiceRate": 0.5389454960823059,
  "isFutanari": false
}
```

この PR を取り入れると以下のように実行でき、
```python
chara.Parameter.prettify()
# or
chara.Parameter
```
以下のように表示される
```json
{
  "version": "0.0.0",
  "sex": 1,
  "lastname": "石川",
  "firstname": "佳穂",
  "nickname": "かほ",
  "personality": 3,
  "bloodType": 2,
  "birthMonth": 7,
  "birthDay": 10,
  "voiceRate": 0.5389454960823059,
  "isFutanari": false
}
```