### PR TITLE
Refactor salvage_character_from_scene.py to use KoikatuSceneData

### DIFF
--- a/samples/salvage_character_from_scene.py
+++ b/samples/salvage_character_from_scene.py
@@ -1,34 +1,31 @@
 #!/usr/bin/env python
-# -*- coding:utf-8 -*-
 
 import copy
-import io
 import os
 import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-from kkloader import KoikatuCharaData  # noqa
+from kkloader import KoikatuSceneData  # noqa
 
 
 def search_characters_from_scene(filename):
-    data = None
-    with open(filename, "br") as f:
-        data = f.read()
+    """
+    Load a Koikatu scene file and extract all character data.
+
+    Uses KoikatuSceneData to properly parse the scene structure
+    and extract character objects (type 0) including nested children.
+    """
+    scene = KoikatuSceneData.load(filename)
 
     charas = []
-    idx = 0
-    while True:
-        idx = data.find(
-            b"\x64\x00\x00\x00\x12\xE3\x80\x90\x4B\x6F\x69\x4B\x61\x74\x75\x43\x68\x61\x72\x61\xE3\x80",
-            idx,
-        )
-        if idx == -1:
-            break
-        data_stream = io.BytesIO(data[idx:])
-        chara = KoikatuCharaData.load(data_stream, contains_png=False)
-        charas.append(chara)
-        idx += 1
+    # Use walk() to iterate through all objects including nested children
+    for _, obj_info in scene.walk():
+        # Type 0 is character (OICharInfo)
+        if obj_info["type"] == 0:
+            chara = obj_info["data"]["character"]
+            charas.append(chara)
+
     return charas
 
 


### PR DESCRIPTION
- Replace manual binary pattern search with KoikatuSceneData.load()
- Use walk() method to iterate through all scene objects
- Extract characters from type 0 objects
- Remove unnecessary coding declaration and io import