### PR TITLE
Resolve Honeycome unknown fields in scene object IO

### DIFF
--- a/kkloader/HoneycomeSceneObjectLoader.py
+++ b/kkloader/HoneycomeSceneObjectLoader.py
@@ -633,7 +633,8 @@ class HoneycomeSceneObjectLoader:
         # Read light-specific data
         data["no"] = load_type(data_stream, "i")
 
-        data["unknown_bytes"] = data_stream.read(2)  # 0x0101
+        data["lightSwitch"] = bool(load_type(data_stream, "b"))
+        data["displayTarget"] = bool(load_type(data_stream, "b"))
         color_bytes = load_string(data_stream)
         data["color"] = HoneycomeSceneObjectLoader.parse_color_json(color_bytes.decode("utf-8"))
 
@@ -961,8 +962,9 @@ class HoneycomeSceneObjectLoader:
         # Write no
         data_stream.write(struct.pack("i", data["no"]))
 
-        # Write unknown_bytes (2 bytes)
-        data_stream.write(data["unknown_bytes"])
+        # Write light settings flags
+        data_stream.write(struct.pack("b", int(data["lightSwitch"])))
+        data_stream.write(struct.pack("b", int(data["displayTarget"])))
 
         # Write color as JSON string
         HoneycomeSceneObjectLoader._save_color_json(data_stream, data["color"])


### PR DESCRIPTION
- Mapped multiple Honeycome unknown_* fields to named properties across item, pattern, light, and character loaders.
- Updated pattern IO to always read/write key, filepath, clamp, uv, and rot as a single consistent format.
- Updated item IO to serialize title, anime_pattern, anime_speed, shadow_type/switch/strength, and the panel pattern block; removed legacy
  unknown bytes.
- Updated light IO to serialize lightSwitch and displayTarget flags instead of raw 2‑byte blobs.
- Updated character IO to serialize the new voiceCtrl structure (length‑prefixed, parsed fields) and expanded anime_option_param to 3 floats;
  renamed unknown_bytes_2 to unknown.