### PR TITLE
Standardize `__repr__` for character/scene data

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,6 +23,8 @@ $ python -m pip install kkloader
 $ python
 >>> from kkloader import KoikatuCharaData # モジュールを読み込む
 >>> kc = KoikatuCharaData.load("./data/kk_chara.png") # キャラデータを読み込む
+>>> kc
+KoikatuCharaData(product_no=100, header='【KoiKatuChara】', version='0.0.0', name='白峰 一乃 ( かずのん )', blocks=['Custom', 'Coordinate', 'Parameter', 'Status'], has_kkex=False, original_file_path='/path/to/data/kk_chara.png')
 >>> kc["Parameter"]["nickname"] # ニックネームを表示する
 'かずのん'
 >>> kc["Parameter"]["nickname"] = "ちかりん" # ニックネームを"ちかりん"にする

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ If you just want to quickly try out this module, you can click the "Open In Cola
 $ python
 >>> from kkloader import KoikatuCharaData # Import the module.
 >>> kc = KoikatuCharaData.load("./data/kk_chara.png") # Load character data.
+>>> kc
+KoikatuCharaData(product_no=100, header='【KoiKatuChara】', version='0.0.0', name='白峰 一乃 ( かずのん )', blocks=['Custom', 'Coordinate', 'Parameter', 'Status'], has_kkex=False, original_file_path='/path/to/data/kk_chara.png')
 >>> kc["Parameter"]["nickname"] # Print the character's nickname.
 'かずのん'
 >>> kc["Parameter"]["nickname"] = "chikarin" # Change the nickname.

--- a/kkloader/AicomiCharaData.py
+++ b/kkloader/AicomiCharaData.py
@@ -25,7 +25,6 @@ class AicomiCharaData(kkloader.KoikatuCharaData):
             "GameInfo_AC": GameInfo_AC,
         }
 
-
 class GameParameter_AC(BlockData):
     """Block data for Aicomi game parameters."""
 

--- a/kkloader/EmocreCharaData.py
+++ b/kkloader/EmocreCharaData.py
@@ -105,14 +105,3 @@ class EmocreCharaData(kkloader.KoikatuCharaData):
             "packages": self.packages,
         }
         return data
-
-    def __str__(self) -> str:
-        """Return a string representation of the EmotionCreators character.
-
-        Returns:
-            String containing header, name, user ID, and data ID.
-        """
-        header = self.header.decode("utf-8")
-        userid = self.userid.decode("ascii")
-        dataid = self.dataid.decode("ascii")
-        return "{}, {}, userid:{}, dataid:{}".format(header, self["Parameter"]["fullname"], userid, dataid)

--- a/kkloader/HoneycomeCharaData.py
+++ b/kkloader/HoneycomeCharaData.py
@@ -32,20 +32,6 @@ class HoneycomeCharaData(kkloader.KoikatuCharaData):
             "GameInfo_HC": GameInfo_HC,
         }
 
-    def __str__(self) -> str:
-        """Return a string representation of the Honeycome character.
-
-        Returns:
-            String containing the header and character name.
-        """
-        header = self.header.decode("utf-8")
-        param = self["Parameter"].data
-        lastname = param.get("lastname", "")
-        firstname = param.get("firstname", "")
-        name = "{} {}".format(lastname, firstname).strip()
-        return "{}, {}".format(header, name)
-
-
 class Custom(BlockData):
     """Block data for Honeycome custom character appearance (face, body only).
 

--- a/kkloader/HoneycomeSceneData.py
+++ b/kkloader/HoneycomeSceneData.py
@@ -1,6 +1,7 @@
 """Honeycome scene data loader and saver."""
 
 import io
+import os
 import struct
 import sys
 from contextlib import contextmanager
@@ -58,6 +59,7 @@ class HoneycomeSceneData:
         self.unknown_tail_extra: bytes | None = None
         self.crypto_key: bytes | None = None
         self.crypto_iv: bytes | None = None
+        self.original_filename: str | None = None
 
     @staticmethod
     @contextmanager
@@ -92,11 +94,13 @@ class HoneycomeSceneData:
         hs = cls()
         hs.crypto_key = None
         hs.crypto_iv = None
+        hs.original_filename = None
 
         if isinstance(filelike, str):
             with open(filelike, "br") as f:
                 data = f.read()
             data_stream = io.BytesIO(data)
+            hs.original_filename = os.path.abspath(filelike)
         elif isinstance(filelike, bytes):
             data_stream = io.BytesIO(filelike)
         elif isinstance(filelike, io.BytesIO):
@@ -347,3 +351,16 @@ class HoneycomeSceneData:
     def __str__(self):
         """String representation of the scene data"""
         return f"HoneycomeSceneData(version={self.version}, objects={len(self.objects)})"
+
+    def __repr__(self):
+        """Return a concise debug representation of Honeycome scene data."""
+        return (
+            f"{self.__class__.__name__}("
+            f"version={self.version!r}, "
+            f"title={self.title!r}, "
+            f"user_id={self.user_id!r}, "
+            f"data_id={self.data_id!r}, "
+            f"original_filename={self.original_filename!r}, "
+            f"footer_marker={self.footer_marker!r}"
+            ")"
+        )

--- a/kkloader/KoikatuSceneData.py
+++ b/kkloader/KoikatuSceneData.py
@@ -6,6 +6,7 @@ Scene files are PNG images with binary scene data appended after the PNG IEND ch
 
 import io
 import json
+import os
 import struct
 from typing import Any, Self
 
@@ -93,6 +94,7 @@ class KoikatuSceneData:
         self.mod_unknown: int = 0
         self.mod_data: Any = None
         self.mod_tail: bytes = b""
+        self.original_filename: str | None = None
 
     @classmethod
     def load(cls, filelike: str | bytes | io.BytesIO) -> Self:
@@ -106,11 +108,13 @@ class KoikatuSceneData:
             KoikatuSceneData: The loaded scene data
         """
         ks = cls()
+        ks.original_filename = None
 
         if isinstance(filelike, str):
             with open(filelike, "br") as f:
                 data = f.read()
             data_stream = io.BytesIO(data)
+            ks.original_filename = os.path.abspath(filelike)
         elif isinstance(filelike, bytes):
             data_stream = io.BytesIO(filelike)
         elif isinstance(filelike, io.BytesIO):
@@ -577,6 +581,17 @@ class KoikatuSceneData:
     def __str__(self):
         """String representation of the scene data"""
         return f"KoikatuSceneData(version={self.version}, objects={len(self.objects)})"
+
+    def __repr__(self):
+        """Return a concise debug representation of Koikatu scene data."""
+        return (
+            f"{self.__class__.__name__}("
+            f"version={self.version!r}, "
+            f"original_filename={self.original_filename!r}, "
+            f"tail={self.tail!r}, "
+            f"has_mod={bool(self.mod_header)!r}"
+            ")"
+        )
 
     # ============================================================
     # 3. PRIMITIVE TYPE HELPERS

--- a/kkloader/SummerVacationCharaData.py
+++ b/kkloader/SummerVacationCharaData.py
@@ -25,20 +25,6 @@ class SummerVacationCharaData(kkloader.KoikatuCharaData):
             "GameInfo_SV": GameInfo_SV,
         }
 
-    def __str__(self) -> str:
-        """Return a string representation of the SummerVacation character.
-
-        Returns:
-            String containing the header and character name.
-        """
-        header = self.header.decode("utf-8")
-        param = self["Parameter"].data
-        lastname = param.get("lastname", "")
-        firstname = param.get("firstname", "")
-        name = "{} {}".format(lastname, firstname).strip()
-        return "{}, {}".format(header, name)
-
-
 class GameParameter_SV(BlockData):
     """Block data for SummerVacationScramble game parameters."""
 

--- a/test/test_honeycomedata.py
+++ b/test/test_honeycomedata.py
@@ -21,6 +21,25 @@ def test_load_honeycome_scene_items():
     assert has_folder, "Expected at least one folder object in hc_scene_items.png"
 
 
+def test_honeycome_scene_repr_fields():
+    scene_data = HoneycomeSceneData.load("./data/hc_scene_items.png")
+    repr_text = repr(scene_data)
+
+    assert f"version={scene_data.version!r}" in repr_text
+    assert f"title={scene_data.title!r}" in repr_text
+    assert f"user_id={scene_data.user_id!r}" in repr_text
+    assert f"data_id={scene_data.data_id!r}" in repr_text
+    assert f"original_filename={os.path.abspath('./data/hc_scene_items.png')!r}" in repr_text
+    assert f"footer_marker={scene_data.footer_marker!r}" in repr_text
+
+
+def test_honeycome_scene_original_filename_for_bytes_input():
+    with open("./data/hc_scene_items.png", "rb") as f:
+        raw_data = f.read()
+    scene_data = HoneycomeSceneData.load(raw_data)
+    assert scene_data.original_filename is None
+
+
 def test_honeycome_scene_to_dict():
     """Test converting a Honeycome scene to a dictionary"""
     scene_data = HoneycomeSceneData.load("./data/hc_scene_items.png")

--- a/test/test_scenedata.py
+++ b/test/test_scenedata.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 from kkloader import KoikatuSceneData
@@ -29,6 +30,27 @@ def test_load_simple_scene():
     assert "colors" in obj_data
     assert "patterns" in obj_data
     assert "panel" in obj_data
+
+
+def test_koikatu_scene_repr_fields():
+    scene_data = KoikatuSceneData.load("./data/kk_scene_simple.png")
+    repr_text = repr(scene_data)
+    assert f"version={scene_data.version!r}" in repr_text
+    assert f"original_filename={os.path.abspath('./data/kk_scene_simple.png')!r}" in repr_text
+    assert f"tail={scene_data.tail!r}" in repr_text
+    assert "has_mod=False" in repr_text
+
+
+def test_koikatu_scene_repr_has_mod_for_mod_scene():
+    scene_data = KoikatuSceneData.load("./data/kk_scene_mod.png")
+    assert "has_mod=True" in repr(scene_data)
+
+
+def test_koikatu_scene_original_filename_for_bytes_input():
+    with open("./data/kk_scene_simple.png", "rb") as f:
+        raw_data = f.read()
+    scene_data = KoikatuSceneData.load(raw_data)
+    assert scene_data.original_filename is None
 
 
 def count_types_recursive(objects):


### PR DESCRIPTION
## Summary

This PR introduces consistent, informative `__repr__` output across character and scene data classes.

The goal is to make `>>> obj` immediately useful for debugging without requiring manual field inspection.

## What Changed

### Character (`KoikatuCharaData` base + subclasses)

- Added a unified `__repr__` format in `KoikatuCharaData`
- Included key metadata in repr:
  - `product_no`
  - `header`
  - `version`
  - `name`
  - `blocks` (list)
  - `has_kkex`
  - `original_file_path` (set when loaded from string path)
- Added optional ID fields when available:
  - `userid`
  - `dataid`
  - sourced from header fields or `About` block (`userID` / `dataID`)
- Unified name inference in base logic (`fullname` or `lastname/firstname/nickname`)
- Removed per-subclass name repr overrides where redundant
- Character string display now effectively uses repr behavior (no separate custom string formatting)

### Scene (`KoikatuSceneData`, `HoneycomeSceneData`)

- Added `original_filename` (set when `load()` receives a string path)
- Added concise `__repr__` outputs:

#### `KoikatuSceneData.__repr__`
- `version`
- `original_filename`
- `tail`
- `has_mod`

#### `HoneycomeSceneData.__repr__`
- `version`
- `title`
- `user_id`
- `data_id`
- `original_filename`
- `footer_marker`

## Example repr outputs

### Character
```py
KoikatuCharaData(
  product_no=100,
  header='【KoiKatuChara】',
  version='0.0.0',
  name='白峰 一乃 ( かずのん )',
  blocks=['Custom', 'Coordinate', 'Parameter', 'Status'],
  has_kkex=False,
  original_file_path='/path/to/data/kk_chara.png'
)
```

### Koikatu scene

```py
KoikatuSceneData(
  version='1.1.2.1',
  original_filename='/path/to/data/kk_scene.png',
  tail='【KStudio】',
  has_mod=False
)
```

### Honeycome scene

```py
HoneycomeSceneData(
  version='1.0.0',
  title='アイテム列挙',
  user_id='...',
  data_id='...',
  original_filename='/path/to/data/hc_scene.png',
  footer_marker='【DigitalCraft】'
)
```
