### PR TITLE
Add typed scene walk filters and type-name counters for Koikatu/Honeycome

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -192,7 +192,7 @@ for key, obj, depth in scene.walk(include_depth=True):
     print(f"{indent}[depth={depth}] Key: {key}, Type: {obj_type}")
 
 # typeを指定してのイテレーションも可能
-for key, obj in scene.walk(type=KoikatuSceneData.CHARACTER):
+for key, obj in scene.walk(object_type=KoikatuSceneData.CHARACTER):
     print(f"Character Key: {key}")
 ```
 
@@ -210,7 +210,7 @@ from kkloader import KoikatuSceneData
 scene = KoikatuSceneData.load("./data/kk_scene.png")
 
 # シーンに含まれるキャラオブジェクトのみをイテレーションする
-for _, obj_info in scene.walk(type=KoikatuSceneData.CHARACTER):
+for _, obj_info in scene.walk(object_type=KoikatuSceneData.CHARACTER):
     chara = obj_info["data"]["character"]
 
     # キャラデータの顔のサムネイル画像をpngデータにする

--- a/README.ja.md
+++ b/README.ja.md
@@ -190,6 +190,10 @@ for key, obj, depth in scene.walk(include_depth=True):
     indent = "  " * depth
     obj_type = obj["type"]
     print(f"{indent}[depth={depth}] Key: {key}, Type: {obj_type}")
+
+# typeを指定してのイテレーションも可能
+for key, obj in scene.walk(type=KoikatuSceneData.CHARACTER):
+    print(f"Character Key: {key}")
 ```
 
 オブジェクトタイプ: 0=Character, 1=Item, 2=Light, 3=Folder, 4=Route, 5=Camera, 7=Text
@@ -205,17 +209,15 @@ from kkloader import KoikatuSceneData
 # シーンデータのロード
 scene = KoikatuSceneData.load("./data/kk_scene.png")
 
-# シーンに含まれるオブジェクトをすべてイテレーションする
-for _, obj_info in scene.walk():
-    # Type 0がキャラデータを表している
-    if obj_info["type"] == 0:
-        chara = obj_info["data"]["character"]
+# シーンに含まれるキャラオブジェクトのみをイテレーションする
+for _, obj_info in scene.walk(type=KoikatuSceneData.CHARACTER):
+    chara = obj_info["data"]["character"]
 
-        # キャラデータの顔のサムネイル画像をpngデータにする
-        chara.image = copy.deepcopy(chara.face_image)
+    # キャラデータの顔のサムネイル画像をpngデータにする
+    chara.image = copy.deepcopy(chara.face_image)
 
-        # キャラデータの保存
-        chara.save("./data/{}.png".format(name))
+    # キャラデータの保存
+    chara.save("./data/{}.png".format(name))
 ```
 
 ### その他

--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ for key, obj, depth in scene.walk(include_depth=True):
     indent = "  " * depth
     obj_type = obj["type"]
     print(f"{indent}[depth={depth}] Key: {key}, Type: {obj_type}")
+
+# Type-filtered iteration is also possible
+for key, obj in scene.walk(type=KoikatuSceneData.CHARACTER):
+    print(f"Character Key: {key}")
 ```
 
 Object types: 0=Character, 1=Item, 2=Light, 3=Folder, 4=Route, 5=Camera, 7=Text
@@ -204,17 +208,15 @@ from kkloader import KoikatuSceneData
 # Load scene data
 scene = KoikatuSceneData.load("./data/kk_scene.png")
 
-# Iterate over all objects in the scene
-for _, obj_info in scene.walk():
-    # Type 0 represents character data
-    if obj_info["type"] == 0:
-        chara = obj_info["data"]["character"]
+# Iterate only character objects in the scene
+for _, obj_info in scene.walk(type=KoikatuSceneData.CHARACTER):
+    chara = obj_info["data"]["character"]
 
-        # Use face thumbnail as the character card image
-        chara.image = copy.deepcopy(chara.face_image)
+    # Use face thumbnail as the character card image
+    chara.image = copy.deepcopy(chara.face_image)
 
-        # Save the character data
-        chara.save("./data/{}.png".format(name))
+    # Save the character data
+    chara.save("./data/{}.png".format(name))
 ```
 
 ### Others

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ for key, obj, depth in scene.walk(include_depth=True):
     print(f"{indent}[depth={depth}] Key: {key}, Type: {obj_type}")
 
 # Type-filtered iteration is also possible
-for key, obj in scene.walk(type=KoikatuSceneData.CHARACTER):
+for key, obj in scene.walk(object_type=KoikatuSceneData.CHARACTER):
     print(f"Character Key: {key}")
 ```
 
@@ -209,7 +209,7 @@ from kkloader import KoikatuSceneData
 scene = KoikatuSceneData.load("./data/kk_scene.png")
 
 # Iterate only character objects in the scene
-for _, obj_info in scene.walk(type=KoikatuSceneData.CHARACTER):
+for _, obj_info in scene.walk(object_type=KoikatuSceneData.CHARACTER):
     chara = obj_info["data"]["character"]
 
     # Use face thumbnail as the character card image

--- a/kkloader/HoneycomeSceneData.py
+++ b/kkloader/HoneycomeSceneData.py
@@ -285,7 +285,7 @@ class HoneycomeSceneData:
         encryptor = Cipher(algorithms.AES(self.crypto_key), modes.CBC(self.crypto_iv), backend=default_backend()).encryptor()
         return encryptor.update(data) + encryptor.finalize()
 
-    def walk(self, include_depth: bool = False, object_type: int | None = None, type: int | None = None):
+    def walk(self, include_depth: bool = False, object_type: int | None = None):
         """
         Recursively iterate over all objects in the scene, including nested child objects.
 
@@ -301,8 +301,6 @@ class HoneycomeSceneData:
                           If False, yields (key, obj_info) tuples.
             object_type: Optional object type filter. If provided, only objects
                          with matching type are yielded.
-            type: Alias of object_type for ergonomic calls like
-                  walk(type=HoneycomeSceneData.FOLDER).
 
         Yields:
             If include_depth is False:
@@ -320,17 +318,13 @@ class HoneycomeSceneData:
             >>> for key, obj, depth in scene.walk(include_depth=True):
             ...     print(f"{'  ' * depth}Object {key}: type={obj['type']}")
             >>> # Filter by type (characters):
-            >>> for key, obj in scene.walk(type=HoneycomeSceneData.CHARACTER):
+            >>> for key, obj in scene.walk(object_type=HoneycomeSceneData.CHARACTER):
             ...     print(f"Character key={key}")
         """
-        if object_type is not None and type is not None and object_type != type:
-            raise ValueError("object_type and type must match when both are provided.")
-        filter_type = object_type if object_type is not None else type
-
         def _should_yield(obj_info: dict[str, Any]) -> bool:
-            if filter_type is None:
+            if object_type is None:
                 return True
-            return obj_info.get("type") == filter_type
+            return obj_info.get("type") == object_type
 
         def _walk_children(obj_info, depth):
             """Recursively walk through child objects."""

--- a/kkloader/HoneycomeSceneData.py
+++ b/kkloader/HoneycomeSceneData.py
@@ -61,6 +61,15 @@ class HoneycomeSceneData:
         self.crypto_iv: bytes | None = None
         self.original_filename: str | None = None
 
+    OBJECT_TYPE_NAMES: dict[int, str] = {
+        0: "Character",
+        1: "Item",
+        2: "Light",
+        3: "Folder",
+        4: "Route",
+        5: "Camera",
+    }
+
     @staticmethod
     @contextmanager
     def _temp_recursionlimit(limit: int):
@@ -336,6 +345,17 @@ class HoneycomeSceneData:
             else:
                 yield key, obj_info
             yield from _walk_children(obj_info, 0)
+
+    def count_object_types(self) -> dict[str, int]:
+        """Count scene objects by type name across the full object tree."""
+        counts: dict[str, int] = {}
+        for _, obj_info in self.walk():
+            obj_type = obj_info.get("type")
+            if not isinstance(obj_type, int):
+                continue
+            name = self.OBJECT_TYPE_NAMES.get(obj_type, f"Unknown({obj_type})")
+            counts[name] = counts.get(name, 0) + 1
+        return counts
 
     def to_dict(self):
         """Convert the scene data to a dictionary"""

--- a/kkloader/KoikatuSceneData.py
+++ b/kkloader/KoikatuSceneData.py
@@ -96,6 +96,16 @@ class KoikatuSceneData:
         self.mod_tail: bytes = b""
         self.original_filename: str | None = None
 
+    OBJECT_TYPE_NAMES: dict[int, str] = {
+        0: "Character",
+        1: "Item",
+        2: "Light",
+        3: "Folder",
+        4: "Route",
+        5: "Camera",
+        7: "Text",
+    }
+
     @classmethod
     def load(cls, filelike: str | bytes | io.BytesIO) -> Self:
         """
@@ -533,6 +543,17 @@ class KoikatuSceneData:
             else:
                 yield key, obj_info
             yield from _walk_children(obj_info, 0)
+
+    def count_object_types(self) -> dict[str, int]:
+        """Count scene objects by type name across the full object tree."""
+        counts: dict[str, int] = {}
+        for _, obj_info in self.walk():
+            obj_type = obj_info.get("type")
+            if not isinstance(obj_type, int):
+                continue
+            name = self.OBJECT_TYPE_NAMES.get(obj_type, f"Unknown({obj_type})")
+            counts[name] = counts.get(name, 0) + 1
+        return counts
 
     def to_dict(self):
         """Convert the scene data to a dictionary"""

--- a/kkloader/KoikatuSceneData.py
+++ b/kkloader/KoikatuSceneData.py
@@ -484,7 +484,7 @@ class KoikatuSceneData:
 
         return data_stream.getvalue()
 
-    def walk(self, include_depth: bool = False, object_type: int | None = None, type: int | None = None):
+    def walk(self, include_depth: bool = False, object_type: int | None = None):
         """
         Recursively iterate over all objects in the scene, including nested child objects.
 
@@ -500,8 +500,6 @@ class KoikatuSceneData:
                           If False, yields (key, obj_info) tuples.
             object_type: Optional object type filter. If provided, only objects
                          with matching type are yielded.
-            type: Alias of object_type for ergonomic calls like
-                  walk(type=KoikatuSceneData.CHARACTER).
 
         Yields:
             If include_depth is False:
@@ -519,17 +517,13 @@ class KoikatuSceneData:
             >>> for key, obj, depth in scene.walk(include_depth=True):
             ...     print(f"{'  ' * depth}Object {key}: type={obj['type']}")
             >>> # Filter by type (characters):
-            >>> for key, obj in scene.walk(type=KoikatuSceneData.CHARACTER):
+            >>> for key, obj in scene.walk(object_type=KoikatuSceneData.CHARACTER):
             ...     print(f"Character key={key}")
         """
-        if object_type is not None and type is not None and object_type != type:
-            raise ValueError("object_type and type must match when both are provided.")
-        filter_type = object_type if object_type is not None else type
-
         def _should_yield(obj_info: dict[str, Any]) -> bool:
-            if filter_type is None:
+            if object_type is None:
                 return True
-            return obj_info.get("type") == filter_type
+            return obj_info.get("type") == object_type
 
         def _walk_children(obj_info, depth):
             """Recursively walk through child objects."""

--- a/kkloader/KoikatuSceneData.py
+++ b/kkloader/KoikatuSceneData.py
@@ -32,6 +32,14 @@ class KoikatuSceneData:
         And many more scene settings...
     """
 
+    CHARACTER = 0
+    ITEM = 1
+    LIGHT = 2
+    FOLDER = 3
+    ROUTE = 4
+    CAMERA = 5
+    TEXT = 7
+
     def __init__(self) -> None:
         """Initialize scene data with default values for all fields."""
         self.image: bytes | None = None
@@ -97,13 +105,13 @@ class KoikatuSceneData:
         self.original_filename: str | None = None
 
     OBJECT_TYPE_NAMES: dict[int, str] = {
-        0: "Character",
-        1: "Item",
-        2: "Light",
-        3: "Folder",
-        4: "Route",
-        5: "Camera",
-        7: "Text",
+        CHARACTER: "Character",
+        ITEM: "Item",
+        LIGHT: "Light",
+        FOLDER: "Folder",
+        ROUTE: "Route",
+        CAMERA: "Camera",
+        TEXT: "Text",
     }
 
     @classmethod
@@ -476,7 +484,7 @@ class KoikatuSceneData:
 
         return data_stream.getvalue()
 
-    def walk(self, include_depth: bool = False):
+    def walk(self, include_depth: bool = False, object_type: int | None = None, type: int | None = None):
         """
         Recursively iterate over all objects in the scene, including nested child objects.
 
@@ -490,6 +498,10 @@ class KoikatuSceneData:
         Args:
             include_depth: If True, yields (key, obj_info, depth) tuples.
                           If False, yields (key, obj_info) tuples.
+            object_type: Optional object type filter. If provided, only objects
+                         with matching type are yielded.
+            type: Alias of object_type for ergonomic calls like
+                  walk(type=KoikatuSceneData.CHARACTER).
 
         Yields:
             If include_depth is False:
@@ -506,7 +518,18 @@ class KoikatuSceneData:
             >>> # With depth:
             >>> for key, obj, depth in scene.walk(include_depth=True):
             ...     print(f"{'  ' * depth}Object {key}: type={obj['type']}")
+            >>> # Filter by type (characters):
+            >>> for key, obj in scene.walk(type=KoikatuSceneData.CHARACTER):
+            ...     print(f"Character key={key}")
         """
+        if object_type is not None and type is not None and object_type != type:
+            raise ValueError("object_type and type must match when both are provided.")
+        filter_type = object_type if object_type is not None else type
+
+        def _should_yield(obj_info: dict[str, Any]) -> bool:
+            if filter_type is None:
+                return True
+            return obj_info.get("type") == filter_type
 
         def _walk_children(obj_info, depth):
             """Recursively walk through child objects."""
@@ -522,26 +545,29 @@ class KoikatuSceneData:
             if obj_type == 0:
                 for child_key, child_list in child.items():
                     for idx, child_obj in enumerate(child_list):
-                        if include_depth:
-                            yield (child_key, idx), child_obj, depth + 1
-                        else:
-                            yield (child_key, idx), child_obj
+                        if _should_yield(child_obj):
+                            if include_depth:
+                                yield (child_key, idx), child_obj, depth + 1
+                            else:
+                                yield (child_key, idx), child_obj
                         yield from _walk_children(child_obj, depth + 1)
             else:
                 # Item (1), Folder (3), Route (4) have List[ObjectInfo] structure
                 for idx, child_obj in enumerate(child):
-                    if include_depth:
-                        yield idx, child_obj, depth + 1
-                    else:
-                        yield idx, child_obj
+                    if _should_yield(child_obj):
+                        if include_depth:
+                            yield idx, child_obj, depth + 1
+                        else:
+                            yield idx, child_obj
                     yield from _walk_children(child_obj, depth + 1)
 
         # Iterate over top-level objects
         for key, obj_info in self.objects.items():
-            if include_depth:
-                yield key, obj_info, 0
-            else:
-                yield key, obj_info
+            if _should_yield(obj_info):
+                if include_depth:
+                    yield key, obj_info, 0
+                else:
+                    yield key, obj_info
             yield from _walk_children(obj_info, 0)
 
     def count_object_types(self) -> dict[str, int]:

--- a/samples/salvage_character_from_scene.py
+++ b/samples/salvage_character_from_scene.py
@@ -20,7 +20,7 @@ def search_characters_from_scene(filename):
 
     charas = []
     # Use walk() with type filter to iterate character objects including nested children
-    for _, obj_info in scene.walk(type=KoikatuSceneData.CHARACTER):
+    for _, obj_info in scene.walk(object_type=KoikatuSceneData.CHARACTER):
         chara = obj_info["data"]["character"]
         charas.append(chara)
 

--- a/samples/salvage_character_from_scene.py
+++ b/samples/salvage_character_from_scene.py
@@ -19,12 +19,10 @@ def search_characters_from_scene(filename):
     scene = KoikatuSceneData.load(filename)
 
     charas = []
-    # Use walk() to iterate through all objects including nested children
-    for _, obj_info in scene.walk():
-        # Type 0 is character (OICharInfo)
-        if obj_info["type"] == 0:
-            chara = obj_info["data"]["character"]
-            charas.append(chara)
+    # Use walk() with type filter to iterate character objects including nested children
+    for _, obj_info in scene.walk(type=KoikatuSceneData.CHARACTER):
+        chara = obj_info["data"]["character"]
+        charas.append(chara)
 
     return charas
 

--- a/test/test_honeycomedata.py
+++ b/test/test_honeycomedata.py
@@ -245,25 +245,16 @@ def test_count_object_types_honeycome_scene_objects():
 
 def test_walk_filter_object_type_honeycome():
     scene_data = HoneycomeSceneData.load("./data/hc_scene_objects.png")
-    folders = list(scene_data.walk(type=HoneycomeSceneData.FOLDER))
+    folders = list(scene_data.walk(object_type=HoneycomeSceneData.FOLDER))
     assert len(folders) == scene_data.count_object_types()["Folder"]
     assert all(obj["type"] == HoneycomeSceneData.FOLDER for _, obj in folders)
 
 
 def test_walk_filter_object_type_honeycome_with_depth():
     scene_data = HoneycomeSceneData.load("./data/hc_scene_objects.png")
-    cameras = list(scene_data.walk(include_depth=True, type=HoneycomeSceneData.CAMERA))
+    cameras = list(scene_data.walk(include_depth=True, object_type=HoneycomeSceneData.CAMERA))
     assert len(cameras) == scene_data.count_object_types()["Camera"]
     assert all(obj["type"] == HoneycomeSceneData.CAMERA for _, obj, _ in cameras)
-
-
-def test_walk_filter_type_conflict_honeycome():
-    scene_data = HoneycomeSceneData.load("./data/hc_scene_objects.png")
-    try:
-        list(scene_data.walk(object_type=HoneycomeSceneData.FOLDER, type=HoneycomeSceneData.LIGHT))
-        assert False, "Expected ValueError when object_type and type differ"
-    except ValueError:
-        pass
 
 
 def test_light_data_preservation():

--- a/test/test_honeycomedata.py
+++ b/test/test_honeycomedata.py
@@ -243,6 +243,29 @@ def test_count_object_types_honeycome_scene_objects():
     }
 
 
+def test_walk_filter_object_type_honeycome():
+    scene_data = HoneycomeSceneData.load("./data/hc_scene_objects.png")
+    folders = list(scene_data.walk(type=HoneycomeSceneData.FOLDER))
+    assert len(folders) == scene_data.count_object_types()["Folder"]
+    assert all(obj["type"] == HoneycomeSceneData.FOLDER for _, obj in folders)
+
+
+def test_walk_filter_object_type_honeycome_with_depth():
+    scene_data = HoneycomeSceneData.load("./data/hc_scene_objects.png")
+    cameras = list(scene_data.walk(include_depth=True, type=HoneycomeSceneData.CAMERA))
+    assert len(cameras) == scene_data.count_object_types()["Camera"]
+    assert all(obj["type"] == HoneycomeSceneData.CAMERA for _, obj, _ in cameras)
+
+
+def test_walk_filter_type_conflict_honeycome():
+    scene_data = HoneycomeSceneData.load("./data/hc_scene_objects.png")
+    try:
+        list(scene_data.walk(object_type=HoneycomeSceneData.FOLDER, type=HoneycomeSceneData.LIGHT))
+        assert False, "Expected ValueError when object_type and type differ"
+    except ValueError:
+        pass
+
+
 def test_light_data_preservation():
     """Test that light-specific data is preserved through save/load cycle"""
     scene_data = HoneycomeSceneData.load("./data/hc_scene_objects.png")

--- a/test/test_honeycomedata.py
+++ b/test/test_honeycomedata.py
@@ -226,6 +226,23 @@ def test_load_honeycome_scene_objects():
     assert type_counts.get(4, 0) == 1, "Expected 1 route object"
 
 
+def test_count_object_types_honeycome_scene_items():
+    scene_data = HoneycomeSceneData.load("./data/hc_scene_items.png")
+    assert scene_data.count_object_types() == {"Folder": 76, "Item": 150}
+
+
+def test_count_object_types_honeycome_scene_objects():
+    scene_data = HoneycomeSceneData.load("./data/hc_scene_objects.png")
+    assert scene_data.count_object_types() == {
+        "Folder": 8,
+        "Item": 1,
+        "Character": 1,
+        "Light": 3,
+        "Camera": 1,
+        "Route": 1,
+    }
+
+
 def test_light_data_preservation():
     """Test that light-specific data is preserved through save/load cycle"""
     scene_data = HoneycomeSceneData.load("./data/hc_scene_objects.png")

--- a/test/test_scenedata.py
+++ b/test/test_scenedata.py
@@ -120,6 +120,29 @@ def test_count_object_types_kks_scene():
     assert scene_data.count_object_types() == {"Light": 1, "Folder": 1, "Item": 3, "Character": 1}
 
 
+def test_walk_filter_object_type_koikatu():
+    scene_data = KoikatuSceneData.load("./data/kk_scene.png")
+    chars = list(scene_data.walk(type=KoikatuSceneData.CHARACTER))
+    assert len(chars) == scene_data.count_object_types()["Character"]
+    assert all(obj["type"] == KoikatuSceneData.CHARACTER for _, obj in chars)
+
+
+def test_walk_filter_object_type_koikatu_with_depth():
+    scene_data = KoikatuSceneData.load("./data/kks_scene.png")
+    lights = list(scene_data.walk(include_depth=True, type=KoikatuSceneData.LIGHT))
+    assert len(lights) == scene_data.count_object_types()["Light"]
+    assert all(obj["type"] == KoikatuSceneData.LIGHT for _, obj, _ in lights)
+
+
+def test_walk_filter_type_conflict_koikatu():
+    scene_data = KoikatuSceneData.load("./data/kks_scene.png")
+    try:
+        list(scene_data.walk(object_type=KoikatuSceneData.CHARACTER, type=KoikatuSceneData.LIGHT))
+        assert False, "Expected ValueError when object_type and type differ"
+    except ValueError:
+        pass
+
+
 def test_scene_to_dict():
     """Test converting a scene to a dictionary"""
     scene_data = KoikatuSceneData.load("./data/kk_scene_simple.png")

--- a/test/test_scenedata.py
+++ b/test/test_scenedata.py
@@ -122,25 +122,16 @@ def test_count_object_types_kks_scene():
 
 def test_walk_filter_object_type_koikatu():
     scene_data = KoikatuSceneData.load("./data/kk_scene.png")
-    chars = list(scene_data.walk(type=KoikatuSceneData.CHARACTER))
+    chars = list(scene_data.walk(object_type=KoikatuSceneData.CHARACTER))
     assert len(chars) == scene_data.count_object_types()["Character"]
     assert all(obj["type"] == KoikatuSceneData.CHARACTER for _, obj in chars)
 
 
 def test_walk_filter_object_type_koikatu_with_depth():
     scene_data = KoikatuSceneData.load("./data/kks_scene.png")
-    lights = list(scene_data.walk(include_depth=True, type=KoikatuSceneData.LIGHT))
+    lights = list(scene_data.walk(include_depth=True, object_type=KoikatuSceneData.LIGHT))
     assert len(lights) == scene_data.count_object_types()["Light"]
     assert all(obj["type"] == KoikatuSceneData.LIGHT for _, obj, _ in lights)
-
-
-def test_walk_filter_type_conflict_koikatu():
-    scene_data = KoikatuSceneData.load("./data/kks_scene.png")
-    try:
-        list(scene_data.walk(object_type=KoikatuSceneData.CHARACTER, type=KoikatuSceneData.LIGHT))
-        assert False, "Expected ValueError when object_type and type differ"
-    except ValueError:
-        pass
 
 
 def test_scene_to_dict():

--- a/test/test_scenedata.py
+++ b/test/test_scenedata.py
@@ -105,6 +105,21 @@ def test_load_kks_scene():
     assert type_counts.get(3, 0) == 1  # 1 folder
 
 
+def test_count_object_types_koikatu_scene():
+    scene_data = KoikatuSceneData.load("./data/kk_scene.png")
+    assert scene_data.count_object_types() == {"Folder": 19, "Item": 169, "Character": 1}
+
+
+def test_count_object_types_koikatu_mod_scene():
+    scene_data = KoikatuSceneData.load("./data/kk_scene_mod.png")
+    assert scene_data.count_object_types() == {"Folder": 202, "Item": 202, "Character": 1, "Light": 1}
+
+
+def test_count_object_types_kks_scene():
+    scene_data = KoikatuSceneData.load("./data/kks_scene.png")
+    assert scene_data.count_object_types() == {"Light": 1, "Folder": 1, "Item": 3, "Character": 1}
+
+
 def test_scene_to_dict():
     """Test converting a scene to a dictionary"""
     scene_data = KoikatuSceneData.load("./data/kk_scene_simple.png")


### PR DESCRIPTION
## Summary

This PR improves scene traversal ergonomics for both `KoikatuSceneData` and `HoneycomeSceneData` by adding typed filters to `walk()` and returning human-readable names from `count_object_types()`.

## Changes

### 1. Typed walk filter for scene traversal

Updated `walk()` in both classes:

- `KoikatuSceneData.walk(include_depth=False, object_type=None)`
- `HoneycomeSceneData.walk(include_depth=False, object_type=None)`

Behavior:

- Default (`object_type=None`): unchanged, walks all objects recursively.
- Filtered (`object_type=...`): yields only matching object types while still traversing full tree.

### 2. `count_object_types()` returns object counts grouped by type.

```python
from kkloader import KoikatuSceneData

scene = KoikatuSceneData.load("./data/kk_scene.png")

object_counts = scene.count_object_types()
print(object_counts)
# e.g. {'Character': 1, 'Item': 169, 'Folder': 19}

print("Characters:", object_counts.get("Character", 0))
print("Items:", object_counts.get("Item", 0))
```
