### PR TITLE
Updating sample scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       run: uv sync
     - name: Lint with ruff
       run: |
-        uv run ruff check --select I --output-format=github ./kkloader ./test
+        uv run ruff check --select I --output-format=github ./kkloader ./test ./samples
     - name: Test with pytest
       run: |
         uv run pytest

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ install:
 	uv sync
 
 format:
-	uv run ruff format ./kkloader ./test
-	uv run ruff check --select I --fix ./kkloader ./test
+	uv run ruff format ./kkloader ./test ./samples
+	uv run ruff check --select I --fix ./kkloader ./test ./samples
 
 check:
-	uv run ruff check --select I ./kkloader ./test
+	uv run ruff check --select I ./kkloader ./test ./samples
 	uv run pytest
 
 test:

--- a/README.ja.md
+++ b/README.ja.md
@@ -224,6 +224,42 @@ for _, obj_info in scene.walk(object_type=KoikatuSceneData.CHARACTER):
 
 このモジュールを使った色々な例が [このリポジトリ](https://github.com/great-majority/kk-snippets) にあり、さらに [このサイト](https://kk-snippets.streamlit.app/) で使うこともできます。
 
+# サンプルスクリプトの使い方
+
+`samples/` フォルダにあるスクリプトは[uvで環境を作った](https://docs.astral.sh/uv/getting-started/installation/)後 `uv run` で実行するのが便利です。
+
+### KK/EC間の変換
+
+**[このサイト](https://kk-snippets.streamlit.app/ec-to-kk) を使えば、Python環境を用意することなくブラウザ上で変換できます。**
+
+コイカツ → エモクリ変換:
+```
+uv run samples/kk_to_ec.py <入力ファイル> <出力ファイル>
+```
+
+エモクリ → コイカツ変換:
+```
+uv run samples/ec_to_kk.py <入力ファイル> <出力ファイル>
+```
+
+例:
+```
+uv run samples/kk_to_ec.py ./data/kk_chara.png ./data/converted.png
+uv run samples/ec_to_kk.py ./data/ec_chara.png ./data/converted.png
+```
+
+### コイカツシーンデータからキャラデータを抽出する
+
+シーンファイルに含まれる全キャラクターを指定ディレクトリへ保存します。
+```
+uv run samples/salvage_character_from_scene.py <シーンファイル> <出力ディレクトリ>
+```
+
+例:
+```
+uv run samples/salvage_character_from_scene.py ./data/kk_scene.png ./data/
+```
+
 # 開発に参加する
 *Python 3.11と`uv`コマンドが必要です([このページ](https://docs.astral.sh/uv/getting-started/installation/)を参考にインストールできます)。*
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,42 @@ for _, obj_info in scene.walk(object_type=KoikatuSceneData.CHARACTER):
 
 Various examples using this module can be found in [this repository](https://github.com/great-majority/kk-snippets), and you can also use it on [this site](https://kk-snippets.streamlit.app/).
 
+# Sample Scripts
+
+The scripts in the `samples/` folder can be run directly with `uv run` after [setting up the environment with uv](https://docs.astral.sh/uv/getting-started/installation/).
+
+### Converting between KK and EC
+
+**You can convert character cards directly in your browser at [this site](https://kk-snippets.streamlit.app/ec-to-kk), without needing a Python environment.**
+
+Koikatu → EmotionCreators:
+```
+uv run samples/kk_to_ec.py <input> <output>
+```
+
+EmotionCreators → Koikatu:
+```
+uv run samples/ec_to_kk.py <input> <output>
+```
+
+Example:
+```
+uv run samples/kk_to_ec.py ./data/kk_chara.png ./data/converted.png
+uv run samples/ec_to_kk.py ./data/ec_chara.png ./data/converted.png
+```
+
+### Extract Character Data from a Koikatu Scene
+
+Saves all characters found in a scene file to the specified directory.
+```
+uv run samples/salvage_character_from_scene.py <scene file> <output dir>
+```
+
+Example:
+```
+uv run samples/salvage_character_from_scene.py ./data/kk_scene.png ./data/
+```
+
 # Contributing
 *You'll need Python 3.11 and the `uv` command (see [this page](https://docs.astral.sh/uv/getting-started/installation/) for installation).*
 

--- a/kkloader/AicomiCharaData.py
+++ b/kkloader/AicomiCharaData.py
@@ -25,6 +25,7 @@ class AicomiCharaData(kkloader.KoikatuCharaData):
             "GameInfo_AC": GameInfo_AC,
         }
 
+
 class GameParameter_AC(BlockData):
     """Block data for Aicomi game parameters."""
 

--- a/kkloader/HoneycomeCharaData.py
+++ b/kkloader/HoneycomeCharaData.py
@@ -32,6 +32,7 @@ class HoneycomeCharaData(kkloader.KoikatuCharaData):
             "GameInfo_HC": GameInfo_HC,
         }
 
+
 class Custom(BlockData):
     """Block data for Honeycome custom character appearance (face, body only).
 

--- a/kkloader/HoneycomeSceneData.py
+++ b/kkloader/HoneycomeSceneData.py
@@ -158,10 +158,7 @@ class HoneycomeSceneData:
                 with cls._temp_recursionlimit(recursion_limit):
                     HoneycomeSceneObjectLoader._dispatch_load(data_stream, obj_type, obj_info, version_str)
             except RecursionError as e:
-                raise RuntimeError(
-                    "This scene is too deeply nested, so please increase `recursion_limit`. "
-                    f"(object key={key} type={obj_type})"
-                ) from e
+                raise RuntimeError(f"This scene is too deeply nested, so please increase `recursion_limit`. (object key={key} type={obj_type})") from e
 
             hs.objects[key] = obj_info
 
@@ -321,6 +318,7 @@ class HoneycomeSceneData:
             >>> for key, obj in scene.walk(object_type=HoneycomeSceneData.CHARACTER):
             ...     print(f"Character key={key}")
         """
+
         def _should_yield(obj_info: dict[str, Any]) -> bool:
             if object_type is None:
                 return True
@@ -393,13 +391,4 @@ class HoneycomeSceneData:
 
     def __repr__(self):
         """Return a concise debug representation of Honeycome scene data."""
-        return (
-            f"{self.__class__.__name__}("
-            f"version={self.version!r}, "
-            f"title={self.title!r}, "
-            f"user_id={self.user_id!r}, "
-            f"data_id={self.data_id!r}, "
-            f"original_filename={self.original_filename!r}, "
-            f"footer_marker={self.footer_marker!r}"
-            ")"
-        )
+        return f"{self.__class__.__name__}(version={self.version!r}, title={self.title!r}, user_id={self.user_id!r}, data_id={self.data_id!r}, original_filename={self.original_filename!r}, footer_marker={self.footer_marker!r})"

--- a/kkloader/HoneycomeSceneObjectLoader.py
+++ b/kkloader/HoneycomeSceneObjectLoader.py
@@ -505,15 +505,11 @@ class HoneycomeSceneObjectLoader:
         # Read voice control
         vc_stream = io.BytesIO(data_stream.read(load_type(data_stream, "i")))
         data["voiceCtrl"] = {"list": [], "repeat": None}
-        data["voiceCtrl"]["unknown"] = load_type(vc_stream, "b") # always 0x02
+        data["voiceCtrl"]["unknown"] = load_type(vc_stream, "b")  # always 0x02
         for _ in range(load_type(vc_stream, "i")):
-            voice_info = {
-                "group": load_type(vc_stream, "i"),
-                "category": load_type(vc_stream, "i"),
-                "no": load_type(vc_stream, "i")
-            }
+            voice_info = {"group": load_type(vc_stream, "i"), "category": load_type(vc_stream, "i"), "no": load_type(vc_stream, "i")}
             data["voiceCtrl"]["list"].append(voice_info)
-        data["voiceCtrl"]["repeat"] = load_type(vc_stream, "i") # {0, 1, 2}
+        data["voiceCtrl"]["repeat"] = load_type(vc_stream, "i")  # {0, 1, 2}
 
         # Read visible son
         data["visible_son"] = bool(load_type(data_stream, "b"))
@@ -569,7 +565,7 @@ class HoneycomeSceneObjectLoader:
         data["category"] = load_type(data_stream, "i")
         data["no"] = load_type(data_stream, "i")
 
-        data["anime_pattern"] = load_type(data_stream, "i") # always 0
+        data["anime_pattern"] = load_type(data_stream, "i")  # always 0
         data["anime_speed"] = load_type(data_stream, "f")
 
         data["colors"] = []

--- a/kkloader/KoikatuSceneData.py
+++ b/kkloader/KoikatuSceneData.py
@@ -520,6 +520,7 @@ class KoikatuSceneData:
             >>> for key, obj in scene.walk(object_type=KoikatuSceneData.CHARACTER):
             ...     print(f"Character key={key}")
         """
+
         def _should_yield(obj_info: dict[str, Any]) -> bool:
             if object_type is None:
                 return True
@@ -625,14 +626,7 @@ class KoikatuSceneData:
 
     def __repr__(self):
         """Return a concise debug representation of Koikatu scene data."""
-        return (
-            f"{self.__class__.__name__}("
-            f"version={self.version!r}, "
-            f"original_filename={self.original_filename!r}, "
-            f"tail={self.tail!r}, "
-            f"has_mod={bool(self.mod_header)!r}"
-            ")"
-        )
+        return f"{self.__class__.__name__}(version={self.version!r}, original_filename={self.original_filename!r}, tail={self.tail!r}, has_mod={bool(self.mod_header)!r})"
 
     # ============================================================
     # 3. PRIMITIVE TYPE HELPERS

--- a/kkloader/SummerVacationCharaData.py
+++ b/kkloader/SummerVacationCharaData.py
@@ -25,6 +25,7 @@ class SummerVacationCharaData(kkloader.KoikatuCharaData):
             "GameInfo_SV": GameInfo_SV,
         }
 
+
 class GameParameter_SV(BlockData):
     """Block data for SummerVacationScramble game parameters."""
 

--- a/samples/ec_to_kk.py
+++ b/samples/ec_to_kk.py
@@ -1,22 +1,21 @@
-#!/usr/bin/env python
-# -*- coding:utf-8 -*-
-
 # If all you want to do is *use* this script, just visit
 # https://kk-snippets.streamlit.app/ec-to-kk
 # and you can easily convert character cards in your browser.
 
+import argparse
 import copy
-import os
-import sys
 
-sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-
-from kkloader.EmocreCharaData import EmocreCharaData  # noqa
-from kkloader.KoikatuCharaData import Coordinate, KoikatuCharaData  # noqa
+from kkloader.EmocreCharaData import EmocreCharaData
+from kkloader.KoikatuCharaData import Coordinate, KoikatuCharaData
 
 
 def main():
-    ec = EmocreCharaData.load("./data/ec_chara.png")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input", help="EmotionCreators character card (.png)")
+    parser.add_argument("output", help="output file path")
+    args = parser.parse_args()
+
+    ec = EmocreCharaData.load(args.input)
     kk = KoikatuCharaData()
 
     kk.image = ec.image
@@ -127,7 +126,7 @@ def main():
     kk.Status["backCoordinateType"] = 0
     kk.Status["shoesType"] = 1
 
-    kk.save("./data/converted_ec_chara.png")
+    kk.save(args.output)
 
 
 if __name__ == "__main__":

--- a/samples/ec_to_kk.py
+++ b/samples/ec_to_kk.py
@@ -24,6 +24,8 @@ def main():
     kk.header = "【KoiKatuChara】".encode("utf-8")
     kk.version = "0.0.0".encode("ascii")
     kk.blockdata = copy.deepcopy(ec.blockdata)
+    kk.serialized_lstinfo_order = copy.deepcopy(kk.blockdata)
+    kk.original_lstinfo_order = copy.deepcopy(kk.blockdata)
 
     kk.Custom = copy.deepcopy(ec.Custom)
     kk.Coordinate = Coordinate(data=None, version="0.0.0")

--- a/samples/kk_to_ec.py
+++ b/samples/kk_to_ec.py
@@ -24,6 +24,8 @@ def main():
     ec.dataid = str(uuid.uuid4()).encode("ascii")
     ec.packages = [0]
     ec.blockdata = copy.deepcopy(kk.blockdata)
+    ec.serialized_lstinfo_order = copy.deepcopy(ec.blockdata)
+    ec.original_lstinfo_order = copy.deepcopy(ec.blockdata)
 
     ec.Custom = copy.deepcopy(kk.Custom)
     ec.Coordinate = Coordinate(data=None, version="0.0.1")

--- a/samples/kk_to_ec.py
+++ b/samples/kk_to_ec.py
@@ -1,19 +1,18 @@
-#!/usr/bin/env python
-# -*- coding:utf-8 -*-
-
+import argparse
 import copy
-import os
-import sys
 import uuid
 
-sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-
-from kkloader.EmocreCharaData import EmocreCharaData  # noqa
-from kkloader.KoikatuCharaData import Coordinate, KoikatuCharaData  # noqa
+from kkloader.EmocreCharaData import EmocreCharaData
+from kkloader.KoikatuCharaData import Coordinate, KoikatuCharaData
 
 
 def main():
-    kk = KoikatuCharaData.load("./data/kk_chara.png")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input", help="Koikatu character card (.png)")
+    parser.add_argument("output", help="output file path")
+    args = parser.parse_args()
+
+    kk = KoikatuCharaData.load(args.input)
     ec = EmocreCharaData()
 
     ec.image = kk.image
@@ -109,7 +108,7 @@ def main():
     del ec.Status["backCoordinateType"]
     del ec.Status["shoesType"]
 
-    ec.save("./data/converted_kk_chara.png")
+    ec.save(args.output)
 
 
 if __name__ == "__main__":

--- a/samples/salvage_character_from_scene.py
+++ b/samples/salvage_character_from_scene.py
@@ -1,12 +1,7 @@
-#!/usr/bin/env python
-
+import argparse
 import copy
-import os
-import sys
 
-sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-
-from kkloader import KoikatuSceneData  # noqa
+from kkloader import KoikatuSceneData
 
 
 def search_characters_from_scene(filename):
@@ -28,7 +23,12 @@ def search_characters_from_scene(filename):
 
 
 def main():
-    charas = search_characters_from_scene("./data/kk_scene.png")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input", help="Koikatu scene file (.png)")
+    parser.add_argument("output_dir", help="output directory")
+    args = parser.parse_args()
+
+    charas = search_characters_from_scene(args.input)
 
     for c in charas:
         print(c)
@@ -39,7 +39,7 @@ def main():
             c["Parameter"]["firstname"],
             c["Parameter"]["nickname"],
         )
-        c.save("./data/{}.png".format(name))
+        c.save("{}/{}.png".format(args.output_dir, name))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Added CLI argument support to all three sample scripts (`ec_to_kk.py`, `kk_to_ec.py`, `salvage_character_from_scene.py`) using `argparse`
- Removed legacy `sys.path` manipulation and Python 2-era headers (`#!/usr/bin/env python`, `# -*- coding: utf-8 -*-`)
- Added "Sample Scripts" section to both README files documenting how to run each script with `uv run`