### PR TITLE
Add `summarize_image` option

### DIFF
--- a/kkloader/KoikatuCharaData.py
+++ b/kkloader/KoikatuCharaData.py
@@ -1,5 +1,6 @@
 import base64
 import copy
+import hashlib
 import io
 import json
 import os
@@ -10,6 +11,31 @@ from kkloader.funcs import get_png, load_length, load_type, msg_pack, msg_pack_k
 
 import lz4.block
 import msgpack
+
+_IMAGE_SIGNATURES = {
+    b"\x89PNG\r\n\x1a\n": "PNG",
+    b"\xff\xd8\xff": "JPEG",
+}
+
+
+def _detect_image_format(data: bytes) -> str | None:
+    for sig, fmt in _IMAGE_SIGNATURES.items():
+        if data[: len(sig)] == sig:
+            return fmt
+    return None
+
+
+def _summarize_bytes(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        return {k: _summarize_bytes(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_summarize_bytes(v) for v in obj]
+    if isinstance(obj, bytes):
+        fmt = _detect_image_format(obj)
+        if fmt:
+            md5 = hashlib.md5(obj).hexdigest()
+            return f"[{fmt} image, {len(obj):,} bytes, md5:{md5}]"
+    return obj
 
 
 def _bin_to_str(serial: io.BufferedRandom | bytes) -> str:
@@ -230,12 +256,14 @@ class KoikatuCharaData:
         with open(filename, "bw+") as f:
             f.write(data)
 
-    def save_json(self, filename: str, include_image: bool = False) -> None:
+    def save_json(self, filename: str, include_image: bool = False, summarize_image: bool = True) -> None:
         """Save the character data as JSON.
 
         Args:
             filename: Path to the output JSON file.
             include_image: Whether to include base64-encoded images in the output.
+            summarize_image: Whether to replace image bytes with a human-readable
+                summary (format, size, md5) instead of base64-encoding them.
         """
         data: dict[str, Any] = {}
         header_data = self._make_dict_header(include_image=include_image)
@@ -247,6 +275,9 @@ class KoikatuCharaData:
             versions[v] = getattr(self, v).version
         data["blockdata_versions"] = versions
 
+        if summarize_image:
+            data = _summarize_bytes(data)
+
         with open(filename, "w+") as f:
             json.dump(data, f, indent=2, default=_bin_to_str)
 
@@ -254,7 +285,7 @@ class KoikatuCharaData:
         """Create a dictionary representation of the header.
 
         Args:
-            include_image: Whether to include base64-encoded images.
+            include_image: Whether to include images in the output.
 
         Returns:
             Dictionary containing header information.
@@ -267,8 +298,8 @@ class KoikatuCharaData:
         }
         if include_image:
             if self.image:
-                data.update({"image": base64.b64encode(self.image).decode("ascii")})
-            data.update({"face_image": base64.b64encode(self.face_image).decode("ascii")})
+                data["image"] = self.image
+            data["face_image"] = self.face_image
         return data
 
     def _repr_name(self) -> str:
@@ -469,7 +500,7 @@ class BlockData:
         Returns:
             JSON-formatted string representation.
         """
-        return json.dumps(self.jsonalizable(), indent=2, ensure_ascii=False, default=_bin_to_str)
+        return json.dumps(_summarize_bytes(self.jsonalizable()), indent=2, ensure_ascii=False, default=_bin_to_str)
 
 
 class Custom(BlockData):

--- a/test/test_charadata.py
+++ b/test/test_charadata.py
@@ -1,9 +1,12 @@
+import json
 import os
+import re
 import tempfile
 from pathlib import Path
 
 from kkloader import (
     AicomiCharaData,
+    AmanatsuCharaData,
     EmocreCharaData,
     HoneycomeCharaData,
     KoikatuCharaData,
@@ -11,6 +14,8 @@ from kkloader import (
 )
 
 import pytest
+
+_IMAGE_SUMMARY_RE = re.compile(r"^\[(PNG|JPEG) image, [\d,]+ bytes, md5:[0-9a-f]{32}\]$")
 
 
 def test_load_character():
@@ -324,3 +329,61 @@ def test_character_str_falls_back_to_repr():
     ]
     for chara in samples:
         assert str(chara) == repr(chara)
+
+
+def _collect_image_summaries(obj):
+    """Recursively collect all strings that look like image summaries."""
+    found = []
+    if isinstance(obj, dict):
+        for v in obj.values():
+            found.extend(_collect_image_summaries(v))
+    elif isinstance(obj, list):
+        for v in obj:
+            found.extend(_collect_image_summaries(v))
+    elif isinstance(obj, str) and _IMAGE_SUMMARY_RE.match(obj):
+        found.append(obj)
+    return found
+
+
+def _has_base64_image(obj):
+    """Check if any string value looks like a base64-encoded PNG/JPEG."""
+    if isinstance(obj, dict):
+        return any(_has_base64_image(v) for v in obj.values())
+    if isinstance(obj, list):
+        return any(_has_base64_image(v) for v in obj)
+    if isinstance(obj, str) and len(obj) > 100:
+        return obj.startswith("iVBOR") or obj.startswith("/9j/")
+    return False
+
+
+@pytest.mark.parametrize(
+    "loader,path",
+    [
+        (KoikatuCharaData, "./data/kk_chara.png"),
+        (AmanatsuCharaData, "./data/al_chara.png"),
+        (SummerVacationCharaData, "./data/sv_chara.png"),
+    ],
+    ids=["kk", "al", "svs"],
+)
+class TestSaveJsonSummarizeImage:
+    def test_summarize_image_default(self, loader, path):
+        chara = loader.load(path)
+        tmpfile = tempfile.NamedTemporaryFile(suffix=".json")
+        chara.save_json(tmpfile.name, include_image=True)
+        with open(tmpfile.name) as f:
+            data = json.load(f)
+        summaries = _collect_image_summaries(data)
+        assert len(summaries) >= 1
+        for s in summaries:
+            assert _IMAGE_SUMMARY_RE.match(s)
+        assert not _has_base64_image(data)
+
+    def test_summarize_image_false(self, loader, path):
+        chara = loader.load(path)
+        tmpfile = tempfile.NamedTemporaryFile(suffix=".json")
+        chara.save_json(tmpfile.name, include_image=True, summarize_image=False)
+        with open(tmpfile.name) as f:
+            data = json.load(f)
+        summaries = _collect_image_summaries(data)
+        assert len(summaries) == 0
+        assert _has_base64_image(data)


### PR DESCRIPTION
## Summary
- Add `summarize_image` param to `save_json` (default `True`), replacing image bytes with `[PNG image, 92,087 bytes, md5:...]`
- Apply the same summarization in `BlockData.__str__` / `prettify()`
- Add tests for kk / al / svs